### PR TITLE
add support for yielding exceptions instead of raising them

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -79,7 +79,7 @@ make_datapackage() {
         mkdir -p data
         if [ "${DATAPACKAGE_SSH_PROXY_KEY}" != "" ]; then
             echo "making datapackage for last ${DATAPACKAGE_LAST_DAYS} days"
-            if make_knesset_datapackage --days "${DATAPACKAGE_LAST_DAYS}" --debug --zip --http-proxy "socks5://localhost:8123"; then
+            if make_knesset_datapackage --days "${DATAPACKAGE_LAST_DAYS}" --debug --zip --http-proxy "socks5://localhost:8123 --skip-exceptions"; then
                 echo "OK"
                 return 0
             else

--- a/knesset_datapackage/base.py
+++ b/knesset_datapackage/base.py
@@ -148,6 +148,9 @@ class CsvResource(BaseTabularResource):
                     csv_row.append(value)
                 csv_writer.writerow(csv_row)
 
+    def _get_empty_row(self):
+        return {field["name"]: self._get_field_csv_value("", field) for field in self.descriptor["schema"]["fields"]}
+
     @property
     def csv_path(self):
         if self._base_path:

--- a/knesset_datapackage/base.py
+++ b/knesset_datapackage/base.py
@@ -331,7 +331,15 @@ class BaseDatapackage(DataPackage):
         self.logger.info('making resources')
         for resource in self.resources:
             if isinstance(resource, BaseResource):
-                resource.make(**kwargs)
+                try:
+                    resource.make(**kwargs)
+                except Exception, e:
+                    if kwargs.get("skip_exceptions"):
+                        self.logger.error("got an exception in {} resource: {}".format(resource.descriptor["name"], e.message))
+                        self.logger.exception(e)
+                        resource.descriptor["error"] = e.message
+                    else:
+                        raise e
         self.logger.info('writing datapackage.json')
         with open(os.path.join(self.base_path, "datapackage.json"), 'w') as f:
             f.write(json.dumps(self.descriptor, indent=True)+"\n")

--- a/knesset_datapackage/cli.py
+++ b/knesset_datapackage/cli.py
@@ -25,6 +25,9 @@ def make_datapackage():
     parser.add_argument('--main-committees', action="store_true", help="committees resource: fetch only the active main committees")
     parser.add_argument('--member-id', nargs="*", type=int, help="members resource: fetch only the given member id/s")
     parser.add_argument('--committee-meeting-id', nargs="*", type=int, help="only make data for given committee meeting ids")
+    parser.add_argument('--skip-exceptions', action="store_true", help="try to skip over exceptions as much as possible. "
+                                                                       "errors will be written in datapackage descriptor "
+                                                                       "or inside the relevant data/csv file")
 
     args = parser.parse_args()
 
@@ -64,7 +67,8 @@ def make_datapackage():
                      debug=args.debug,
                      proxies=proxies,
                      member_ids=args.member_id,
-                     committee_meeting_ids=args.committee_meeting_id)
+                     committee_meeting_ids=args.committee_meeting_id,
+                     skip_exceptions=args.skip_exceptions)
 
     if args.zip:
         logger.info('creating datapackage.zip')

--- a/knesset_datapackage/resources/dataservice.py
+++ b/knesset_datapackage/resources/dataservice.py
@@ -1,65 +1,109 @@
 from knesset_datapackage.base import CsvResource
+from knesset_data.dataservice.exceptions import KnessetDataServiceObjectException
 
 
 class BaseKnessetDataServiceCollectionResource(CsvResource):
+
+    # the related knesset_data.dataservice collection class
     collection = None
+
+    # used for logging
     object_name = "object"
+
+    # if True - keeps a list of all objects generated / appended
+    # the objects are available using get_generated_objects method
     track_generated_objects = False
+
+    # getter feature allows to get different types of data of options by fetch kwargs
+    # by default all objects are fetched, you can add more types, see Committees resource for details
     collection_getter_kwargs = {
         # kwarg: getter type
         # OBJECT will be replaced with object_name
         "OBJECT_ids": "ids"
     }
     default_getter_type = "all"
+
+    # True - enables running logic before appending the object
+    # if enabled you should implement the _pre_append method
+    # also, by default - it enables the scraper_errors feature, see below
     enable_pre_append = False
-    get_latest_by_page_estimate = None  # to enable - set to tuple of (ORDERBY_FIELD, ESTIMATED_OBJECTS_PER_DAY)
-                                        # allows to limit amount of returned data in all getter
-                                        # by providing the ordering field and estimated objects per day
+
+    # True - adds a "scraper_errors" column containing a list of errors caught for the object
+    # False - exceptions are raised
+    # None - if enable_pre_append is True, scraper_errors is True, otherwise it's False
+    enable_scraper_errors = None
 
     def __init__(self, name, parent_datapackage_path):
+        """
+        initilizes the resource with the relevant json table schema for this collection
+        """
         super(BaseKnessetDataServiceCollectionResource, self).__init__(name, parent_datapackage_path, self._get_json_table_schema())
         if self.track_generated_objects:
             self._generated_objects = []
 
     def _get_json_table_schema(self):
+        """
+        returns the json table schema for this collection (from thee knesset_data.dataservice collection class)
+        """
         schema = self.collection.get_json_table_schema()
         if self.enable_pre_append:
             schema["fields"].append({"type": "string", "name": "scraper_errors"})
         return schema
 
     def _collection_get(self, object_id, proxies):
+        """
+        get a single object from the collection
+        will raise an exception on any problem
+        """
         return self.collection.get(object_id, proxies=proxies)
 
-    def _collection_get_page(self, order_by, proxies):
-        return self.collection.get_page(order_by=order_by, proxies=proxies)
+    def _collection_get_all(self, proxies, skip_exceptions):
+        """
+        get all the objects from the collection
+        if skip_exception is enabled - will yield KnessetDataserviceObjectException object for each failed object
+        otherwise - stops generating and raises an exception
+        pay attention that some error might still raise exception even if skip_exceptions is True, for example - http request errors
+        """
+        return self.collection.get_all(proxies=proxies, skip_exceptions=skip_exceptions)
 
-    def _collection_get_all(self, proxies):
-        return self.collection.get_all(proxies=proxies)
-
-    def _get_objects_by_ids(self, ids, proxies=None, **make_kwargs):
+    def _get_objects_by_ids(self, getter_kwarg_value, proxies=None, skip_exceptions=False, **make_kwargs):
+        """
+        get specific object ids
+        if skip_exception is enabled - will yield KnessetDataserviceObjectException object for each failed object
+        otherwise - stops generating and raises an exception
+        if skip_exceptions is enabled - no errors will be raised even if http errors (because we are fetching one object at a time)
+        """
+        # currently done inefficiently by getting one object each time
+        # TODO: make it fetch objects in bulk
+        ids = getter_kwarg_value
         self.logger.info('fetching {} ids: {}'.format(self.object_name, ids))
         self.descriptor["description"] = "specific {} ids".format(self.object_name)
-        return (self._collection_get(object_id, proxies=proxies) for object_id in ids)
+        for object_id in ids:
+            try:
+                object = self._collection_get(object_id, proxies=proxies)
+            except Exception, e:
+                if not skip_exceptions:
+                    raise e
+                else:
+                    object = KnessetDataServiceObjectException(self.collection, None, e)
+            yield object
 
-    def _get_objects_by_all(self, void, proxies=None, **make_kwargs):
-        if self.get_latest_by_page_estimate:
-            order_field, estimated_per_day = self.get_latest_by_page_estimate
-            days = make_kwargs.get('days', 5)
-            target_num_results = days * estimated_per_day
-            self.logger.info('fetching up to {} {}s based on ordering of {}'.format(target_num_results, self.object_name, order_field))
-            self.descriptor["description"] = "up to {} {}s based on ordering of {}".format(target_num_results, self.object_name, order_field)
-            num_results = 0
-            while num_results < target_num_results:
-                for object in self._collection_get_page(order_by=(order_field, "desc"), proxies=proxies):
-                    num_results += 1
-                    yield object
-        else:
-            self.logger.info('fetching all {}s'.format(self.object_name))
-            self.descriptor["description"] = "all {}s".format(self.object_name)
-            for object in self._collection_get_all(proxies=proxies):
-                yield object
+
+    def _get_objects_by_all(self, getter_kwarg_value, proxies=None, skip_exceptions=False, **make_kwargs):
+        """
+        get all objects from the collection, usually it means getting them ordered by id ascending
+        see _collection_get_all method for details about exceptions and return values
+        """
+        self.logger.info('fetching all {}s'.format(self.object_name))
+        self.descriptor["description"] = "all {}s".format(self.object_name)
+        for object in self._collection_get_all(proxies=proxies, skip_exceptions=skip_exceptions):
+            yield object
 
     def _get_objects(self, proxies=None, **make_kwargs):
+        """
+        calls the relevant getter function (_get_objects_by_?)
+        see the _get_objects_by_? functions for details about exceptions and return values
+        """
         for kwarg, gtype in self.collection_getter_kwargs.iteritems():
             kwarg = kwarg.replace('OBJECT', self.object_name)
             kwarg_value = make_kwargs.get(kwarg)
@@ -68,25 +112,53 @@ class BaseKnessetDataServiceCollectionResource(CsvResource):
         return getattr(self, "_get_objects_by_{}".format(self.default_getter_type))(None, proxies=proxies, **make_kwargs)
 
     def _pre_append(self, object, **make_kwargs):
-        # allows for extending classes to perform additional work / update related resources
-        # you will need to set enable_pre_append = True for it to work
+        """
+        used if enabled_pre_append is True
+        allows for extending classes to perform additional work / update related resources
+        """
         pass
 
     def _data_generator(self, **make_kwargs):
+        """
+        main method called by CsvResource to get the data
+        yields a dict that corresponds to each csv row according to the json table schema
+        """
+        # _get_objects will try to consider skip_exceptions option and yield exception objects (usually KnessetDataserviceObjectException)
+        # but - there are cases where exceptions will still be raised,
+        # for example, if getting an error when fetching page of results we usually raise an exception and don't continue
         for object in self._get_objects(**make_kwargs):
-            if self.enable_pre_append:
-                scraper_errors = []
-                try:
-                    self._pre_append(object, **make_kwargs)
-                except Exception, e:
-                    scraper_errors.append("exception generating {}: {}".format(self.descriptor["name"], e))
-                    self.logger.warning("exception generating {}, will continue to next object".format(self.descriptor["name"]))
-                    self.logger.exception(e)
-            self.logger.debug('appending {} id {}'.format(self.object_name, object.id))
-            if self.track_generated_objects:
-                self._generated_objects.append(object)
-            row = object.all_field_values()
-            if self.enable_pre_append:
+            enable_scraper_errors = self.enable_scraper_errors or (self.enable_scraper_errors is None and self.enable_pre_append)
+            scraper_errors = [] if enable_scraper_errors else None
+            if make_kwargs.get("skip_exceptions") and isinstance(object, Exception):
+                exception, object = object, None
+            else:
+                exception = None
+            if exception:
+                if enable_scraper_errors:
+                    scraper_errors.append("exception generating {}: {}".format(self.descriptor["name"], exception.message))
+                    row = self._get_empty_row()
+                else:
+                    # we raise an exception here even though the make_kwargs specify to skip_exceptions
+                    # this is because scraper_errors tracking is disabled - so the exception will skip silently
+                    # and we can't have that, can we?
+                    raise exception
+            else:
+                if self.enable_pre_append:
+                    try:
+                        self._pre_append(object, **make_kwargs)
+                    except Exception, e:
+                        self.logger.exception(e)
+                        if enable_scraper_errors:
+                            self.logger.warning("exception generating {}, will continue to next object".format(self.descriptor["name"]))
+                            scraper_errors.append("exception generating {}: {}".format(self.descriptor["name"], e))
+                        else:
+                            self.logger.error("exception generating {}, stopping execution and raising the exception".format(self.descriptor["name"]))
+                            raise e
+                self.logger.debug('appending {} id {}'.format(self.object_name, object.id))
+                if self.track_generated_objects:
+                    self._generated_objects.append(object)
+                row = object.all_field_values()
+            if enable_scraper_errors:
                 row["scraper_errors"] = "\n".join(scraper_errors)
             yield row
 

--- a/knesset_datapackage/resources/members.py
+++ b/knesset_datapackage/resources/members.py
@@ -6,3 +6,4 @@ class MembersResource(BaseKnessetDataServiceCollectionResource):
     collection = Member
     object_name = "member"
     track_generated_objects = True
+    enable_scraper_errors = True

--- a/knesset_datapackage/resources/tests.py
+++ b/knesset_datapackage/resources/tests.py
@@ -115,7 +115,7 @@ class MockCommitteesResource(CommitteesResource):
     def _collection_get_page(self, order_by, proxies):
         pass
 
-    def _collection_get_all(self, proxies):
+    def _collection_get_all(self, proxies, skip_exceptions):
         return [
             Committee({"data": dict(COMMITTEE_SOURCE_DATA, committee_id=1)}),
             Committee({"data": dict(COMMITTEE_SOURCE_DATA, committee_id=2)}),

--- a/knesset_datapackage/resources/tests.py
+++ b/knesset_datapackage/resources/tests.py
@@ -193,18 +193,17 @@ class ResourcesTestCase(BaseDatapackageTestCase):
                                   type("MockProtocolPart", (object,), {"header": "mock header 2", "body": "mock body 2"})],
                         "file_name": ""})
         # appending using the fake protocol
-        resource.append_for_meeting(committee_id, meeting_id, meeting_datetime, meeting_protocol())
+        resource.append_for_meeting(committee_id, meeting_id, meeting_datetime, meeting_protocol(), skip_exceptions=True)
         # checking the created files
         with open(os.path.join(data_root, "committee-meeting-protocols.csv")) as f:
             self.assertEqual(list(csv.reader(f.readlines())),
                              [['committee_id', 'meeting_id', 'text',
                                'parts',
                                'original',
-                               'attending_members'],
+                               'scraper_errors'],
                               ['6',            '7',          'committee_6/7_1953-05-04_00-00-00/protocol.txt',
-                               'committee_6/7_1953-05-04_00-00-00/protocol.csv',
-                               "ERROR: [Errno 2] No such file or directory: ''",
-                               '']])
+                               'committee_6/7_1953-05-04_00-00-00/protocol.csv', '',
+                               "error getting original file: [Errno 2] No such file or directory: ''"]])
         with open(os.path.join(data_root, "committee-meeting-protocols", "committee_6/7_1953-05-04_00-00-00/protocol.txt")) as f:
             self.assertEqual(f.readlines(), ["Hello World!"])
         with open(os.path.join(data_root, "committee-meeting-protocols", "committee_6/7_1953-05-04_00-00-00/protocol.csv")) as f:

--- a/knesset_datapackage/root.py
+++ b/knesset_datapackage/root.py
@@ -11,5 +11,5 @@ class RootDatapackage(BaseDatapackage):
 
         "committees": (CommitteesResource, {"meetings_resource": DatapackageResourceLink("committee-meetings")}),
         "committee-meetings": (CommitteeMeetingsResource, {"protocols_resource": DatapackageResourceLink("committee-meetings-protocols")}),
-        "committee-meetings-protocols": (CommitteeMeetingProtocolsResource, {"members_resource": DatapackageResourceLink("members")}),
+        "committee-meetings-protocols": (CommitteeMeetingProtocolsResource, {}),
     }

--- a/knesset_datapackage/tests/base_datapackage_test_case.py
+++ b/knesset_datapackage/tests/base_datapackage_test_case.py
@@ -20,9 +20,9 @@ class BaseDatapackageTestCase(TestCase):
         self.data_roots.append(data_root)
         return data_root
 
-    def given_dummy_datapackage_was_made(self):
-        datapackage = DummyDatapackage(self.datapackage_root)
-        datapackage.make()
+    def given_dummy_datapackage_was_made(self, without_exceptions=False, **kwargs):
+        datapackage = DummyDatapackage(self.datapackage_root, without_exceptions=without_exceptions)
+        datapackage.make(**kwargs)
         return datapackage
 
     def assert_dummy_resource_file_contains_expected_content(self, f):

--- a/knesset_datapackage/tests/mocks.py
+++ b/knesset_datapackage/tests/mocks.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import os
 from ..resources.members import MembersResource
 from knesset_data.dataservice.mocks import MockMember
+from collections import OrderedDict
 
 
 class DummyResource(BaseResource):
@@ -30,12 +31,24 @@ class DummyResource(BaseResource):
                     yield line[:-1]
 
 
+class DummyResourceWithException(DummyResource):
+
+    def fetch(self, **kwargs):
+        for item in super(DummyResourceWithException, self).fetch(**kwargs):
+            yield item
+        raise Exception("dummy resource exception")
+
+
 class DummyDatapackage(BaseDatapackage):
 
     NAME = "dummy-datapackage"
-    RESOURCES = {
-        "dummy-resource": (DummyResource, {}),
-    }
+    RESOURCES = OrderedDict([("dummy-resource-with-exception", (DummyResourceWithException, {})),
+                             ("dummy-resource", (DummyResource, {})),])
+
+    def __init__(self, base_path, with_dependencies=True, without_exceptions=False):
+        if without_exceptions:
+            del self.RESOURCES["dummy-resource-with-exception"]
+        super(DummyDatapackage, self).__init__(base_path, with_dependencies=with_dependencies)
 
 
 class DummyCsvResource(CsvResource):

--- a/knesset_datapackage/tests/mocks.py
+++ b/knesset_datapackage/tests/mocks.py
@@ -1,6 +1,8 @@
 from knesset_datapackage.base import BaseDatapackage, BaseResource, CsvResource, FilesResource, CsvFilesResource
 from datetime import datetime
 import os
+from ..resources.members import MembersResource
+from knesset_data.dataservice.mocks import MockMember
 
 
 class DummyResource(BaseResource):
@@ -38,14 +40,21 @@ class DummyDatapackage(BaseDatapackage):
 
 class DummyCsvResource(CsvResource):
 
-    def __init__(self, name=None, parent_datapackage_path=None):
+    def __init__(self, name=None, parent_datapackage_path=None, raise_exception=False):
         super(DummyCsvResource, self).__init__(name, parent_datapackage_path, {"fields": [{"name": "date", "type": "datetime"},
                                                                                           {"name": "integer", "type": "integer"},
                                                                                           {"name": "string", "type": "string"}]})
+        self.raise_exception = raise_exception
 
     def _data_generator(self, **make_kwargs):
         yield {"date": datetime(2015, 5, 2), "integer": 5, "string": "hello world!"}
-        yield {"date": datetime(2013, 6, 9), "integer": 3, "string": "goodbye"}
+        if self.raise_exception:
+            if make_kwargs.get("skip_exceptions"):
+                yield "ERROR!"
+            else:
+                raise Exception("raised an exception!")
+        else:
+            yield {"date": datetime(2013, 6, 9), "integer": 3, "string": "goodbye"}
 
 
 class DummyFilesResource(FilesResource):
@@ -77,3 +86,7 @@ class DummyCsvFilesResource(CsvFilesResource):
                 f.write(content)
         yield {"name": "hello world", "text file": "hello_world.txt", "doc file": "hello_world.doc"}
         yield {"name": "goodbye world", "text file": "goodbye_world.txt", "doc file": "goodbye_world.doc"}
+
+
+class MockMembersResource(MembersResource):
+    collection = MockMember

--- a/knesset_datapackage/tests/test_exceptions.py
+++ b/knesset_datapackage/tests/test_exceptions.py
@@ -1,7 +1,8 @@
 from .base_datapackage_test_case import BaseDatapackageTestCase
 from .mocks import DummyCsvResource, MockMembersResource
 import datetime
-from knesset_data.dataservice.exceptions import KnessetDataServiceObjectException
+import os
+import json
 
 
 class ExceptionsTestCase(BaseDatapackageTestCase):
@@ -42,3 +43,40 @@ class ExceptionsTestCase(BaseDatapackageTestCase):
         self.assert_member_row(results_generator.next(), 202, "")
         self.assert_member_row(results_generator.next(), "", "exception generating test-members-resource: member with exception on init")
         self.assert_member_row(results_generator.next(), "", "exception generating test-members-resource: member with exception on parse")
+
+    def test_members_exception_make(self):
+        resource = MockMembersResource("test-members-resource", self.data_root)
+        resource.make(skip_exceptions=True)
+        with open ("{}.csv".format(resource.get_path())) as f:
+            lines = [line.strip().split(",") for line in f.readlines()]
+            header = lines[0]
+            self.assertEqual(header, ['id', 'army_rank_id', 'army_history_desc',
+                                      'army_history_desc_eng', 'country_id', 'country_desc',
+                                      'country_desc_eng', 'minority_type_id', 'education_id',
+                                      'education_desc', 'education_desc_eng', 'marital_status_id',
+                                      'city_id', 'mk_status_id', 'name', 'name_eng', 'first_name',
+                                      'first_name_eng', 'gender', 'birth_date', 'immigration_date',
+                                      'children_number', 'death_date', 'email', 'email_on', 'photo',
+                                      'phone1', 'phone2', 'phone_fax', 'present', 'public_activity',
+                                      'public_activity_eng', 'note', 'note_eng', 'scraper_errors'])
+            self.assertEqual(lines[1:], [['200',] + ["" for void in range(len(header)-1)],
+                                         ['201',] + ["" for void in range(len(header)-1)],
+                                         ['202',] + ["" for void in range(len(header)-1)],
+                                         ["" for void in range(len(header) - 1)] + ['exception generating test-members-resource: member with exception on init'],
+                                         ["" for void in range(len(header) - 1)] + ['exception generating test-members-resource: member with exception on parse'],])
+
+    def test_exception_in_resource_while_making_datapackage(self):
+        # default behavior - stop processing and raise exception
+        with self.assertRaises(Exception) as cm:
+            self.given_dummy_datapackage_was_made()
+        self.assertEqual(cm.exception.message, "dummy resource exception")
+        # with skip_exceptions enabled
+        datapackage = self.given_dummy_datapackage_was_made(skip_exceptions=True)
+        with open (os.path.join(datapackage.base_path, "datapackage.json")) as f:
+            descriptor = json.loads(f.read())
+            self.assertEqual(descriptor, {u'name': u'dummy-datapackage',
+                                          u'resources': [{u'path': u'dummy-resource-with-exception.txt',
+                                                          u'name': u'dummy-resource-with-exception',
+                                                          u'error': u'dummy resource exception'},
+                                                         {u'path': u'dummy-resource.txt',
+                                                          u'name': u'dummy-resource'}]})

--- a/knesset_datapackage/tests/test_exceptions.py
+++ b/knesset_datapackage/tests/test_exceptions.py
@@ -1,0 +1,44 @@
+from .base_datapackage_test_case import BaseDatapackageTestCase
+from .mocks import DummyCsvResource, MockMembersResource
+import datetime
+from knesset_data.dataservice.exceptions import KnessetDataServiceObjectException
+
+
+class ExceptionsTestCase(BaseDatapackageTestCase):
+
+    def assert_member_row(self, row, expected_id, expected_scraper_errors):
+        self.assertEqual(row["id"], expected_id)
+        if expected_scraper_errors is None:
+            self.assertNotIn("scraper_errors", row)
+        else:
+            self.assertEqual(row["scraper_errors"], expected_scraper_errors)
+
+    def test_dummy_exception(self):
+        results_generator = DummyCsvResource("test", self.data_root, raise_exception=True).fetch()
+        self.assertEqual(results_generator.next(), {'date': datetime.datetime(2015, 5, 2, 0, 0), 'integer': 5, 'string': 'hello world!'})
+        with self.assertRaises(Exception) as cm:
+            results_generator.next()
+        self.assertEqual(cm.exception.message, "raised an exception!")
+
+    def test_dummy_skipped_exception(self):
+        results_generator = DummyCsvResource("test", self.data_root, raise_exception=True).fetch(skip_exceptions=True)
+        self.assertEqual(list(results_generator), [{'date': datetime.datetime(2015, 5, 2, 0, 0), 'integer': 5, 'string': 'hello world!'},
+                                                   "ERROR!"])
+
+    def test_members_exception(self):
+        results_generator = MockMembersResource("test-members-resource", self.data_root).fetch()
+        self.assert_member_row(results_generator.next(), 200, "")
+        self.assert_member_row(results_generator.next(), 201, "")
+        self.assert_member_row(results_generator.next(), 202, "")
+        with self.assertRaises(Exception) as cm:
+            results_generator.next()
+        self.assertEqual(cm.exception.message, "member with exception on init")
+
+    def test_members_skipped_exception(self):
+        results_generator = MockMembersResource("test-members-resource", self.data_root).fetch(skip_exceptions=True)
+        # each value returned is a dict representing a csv row
+        self.assert_member_row(results_generator.next(), 200, "")
+        self.assert_member_row(results_generator.next(), 201, "")
+        self.assert_member_row(results_generator.next(), 202, "")
+        self.assert_member_row(results_generator.next(), "", "exception generating test-members-resource: member with exception on init")
+        self.assert_member_row(results_generator.next(), "", "exception generating test-members-resource: member with exception on parse")

--- a/knesset_datapackage/tests/test_zip.py
+++ b/knesset_datapackage/tests/test_zip.py
@@ -22,7 +22,7 @@ class ZipTestCase(BaseDatapackageTestCase):
 
     def test(self):
         # saving to zip
-        datapackage = self.given_dummy_datapackage_was_made()
+        datapackage = self.given_dummy_datapackage_was_made(without_exceptions=True)
         datapackage_zip_file = self.given_datapackage_is_saved_to_zip(datapackage)
         self.dummy_datapackage_zip_should_contain_json_and_dummy_resource(datapackage_zip_file)
         # loading from the zip


### PR DESCRIPTION
* BaseKnessetDataServiceCollectionResource
  * refactoring, cleaning-up, added comments
  * removed get_latest_by_page_estimate option - it was only used in laws scraper which was removed
* general imporvements to exceptions and errors handling
* added --skip-exceptions flag for cli (used by default on travis package)
* removed the attending members from protocols resource (it depends on open knesset data)
  * if you need attending members you have to use knesset-data-python and provide it a list of member names to search for