### PR TITLE
Add support for plenum data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: python
 python:
-  - "2.7"
+  # Python versions encountered in the wild (AKA in Open Knesset)
+  - "2.7.3"
+  - "2.7.9"
+  # Python version on latest Ubuntu - used by developers
+  - "2.7.12"
 addons:
   apt:
     packages:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -5,6 +5,7 @@ set -e  # exit on errors
 [ -f .travis/.env ] && source .travis/.env
 
 pip install --upgrade pip
+pip install -r requirements.txt
 pip install PySocks
 pip install .
 

--- a/knesset_datapackage/cli.py
+++ b/knesset_datapackage/cli.py
@@ -29,6 +29,8 @@ def make_datapackage():
                                                                        "errors will be written in datapackage descriptor "
                                                                        "or inside the relevant data/csv file")
     parser.add_argument('--dry-run', action="store_true", help="skip the actual fetching and saving of data")
+    parser.add_argument('--resource', nargs="*", type=str, help="build only the givdn resource names")
+    parser.add_argument('--mock', action="store_true", help="use mock data - can be useful for testing")
 
     args = parser.parse_args()
 
@@ -70,7 +72,9 @@ def make_datapackage():
                      member_ids=args.member_id,
                      committee_meeting_ids=args.committee_meeting_id,
                      skip_exceptions=args.skip_exceptions,
-                     dry_run=args.dry_run)
+                     dry_run=args.dry_run,
+                     resources=args.resource,
+                     mock=args.mock)
 
     if args.zip:
         logger.info('creating datapackage.zip')

--- a/knesset_datapackage/resources/committees.py
+++ b/knesset_datapackage/resources/committees.py
@@ -77,7 +77,7 @@ class CommitteeMeetingsResource(CsvResource):
                                 self.logger.warning("exception generating protocols resource for committee {}, meeting {}: {}".format(committee_id, meeting.id, e))
                                 self.logger.debug(e, exc_info=1)
                             else:
-                                raise e
+                                raise
                     self.logger.debug('append committee meeting {}'.format(meeting.id))
                     row = meeting.all_field_values()
                     row["scraper_errors"] = "\n".join(scraper_errors)
@@ -145,7 +145,7 @@ class CommitteeMeetingProtocolsResource(CsvFilesResource):
                         self.logger.debug(e, exc_info=1)
                         scraper_errors.append("error getting original file: {}".format(e))
                     else:
-                        raise e
+                        raise
                 # text
                 with open(abs_text_file_path, 'w') as f:
                     try:
@@ -157,7 +157,7 @@ class CommitteeMeetingProtocolsResource(CsvFilesResource):
                             self.logger.debug(e, exc_info=1)
                             scraper_errors.append("error getting text file: {}".format(e))
                         else:
-                            raise e
+                            raise
                 # parts
                 with open(abs_parts_file_path, 'wb') as f:
                     csv_writer = csv.writer(f)
@@ -172,6 +172,6 @@ class CommitteeMeetingProtocolsResource(CsvFilesResource):
                             self.logger.debug(e, exc_info=1)
                             scraper_errors.append("error getting parts file: {}".format(e))
                         else:
-                            raise e
+                            raise
                 row["scraper_errors"] = ", ".join(scraper_errors)
                 self._append(row, **make_kwargs)

--- a/knesset_datapackage/resources/dataservice.py
+++ b/knesset_datapackage/resources/dataservice.py
@@ -83,7 +83,7 @@ class BaseKnessetDataServiceCollectionResource(CsvResource):
                 object = self._collection_get(object_id, proxies=proxies)
             except Exception, e:
                 if not skip_exceptions:
-                    raise e
+                    raise
                 else:
                     object = KnessetDataServiceObjectException(self.collection, None, e)
             yield object
@@ -155,7 +155,7 @@ class BaseKnessetDataServiceCollectionResource(CsvResource):
                             scraper_errors.append("exception generating {}: {}".format(self.descriptor["name"], e))
                         else:
                             self.logger.error("exception generating {}, stopping execution and raising the exception".format(self.descriptor["name"]))
-                            raise e
+                            raise
                 self.logger.debug('appending {} id {}'.format(self.object_name, object.id))
                 if self.track_generated_objects:
                     self._generated_objects.append(object)

--- a/knesset_datapackage/resources/plenum.py
+++ b/knesset_datapackage/resources/plenum.py
@@ -1,0 +1,92 @@
+from knesset_datapackage.base import CsvFilesResource
+from knesset_data.html_scrapers.plenum import PlenumMeetings
+from knesset_data.html_scrapers.mocks import MockPlenumMeetings
+import os, json
+from shutil import copy
+from collections import OrderedDict
+
+
+class PlenumMeetingsResource(CsvFilesResource):
+    PROTOCOL_DATA_FIELDS = ["meeting_num_heb", "knesset_num_heb", "knesset_num", "booklet_num", "booklet_num_heb",
+                            "booklet_meeting_num", "booklet_meeting_num_heb", "day_heb", "date_string_heb",
+                            "time_string", "datetime"]
+
+    def __init__(self, name, parent_datapackage_path):
+        fields = [{"name": "day", "type": "integer", "description": "meeting day (1 = 1st day of month is)"},
+                  {"name": "month", "type": "integer", "description": "meeting month (1 = January, 12 = December)"},
+                  {"name": "year", "type": "integer", "description": "meeting year"},
+                  {"name": "protocol_url", "type": "string", "description": "url to download the protocol file"},
+                  {"name": "protocol_original", "type": "string", "description": "original file (without processing), in case of error will be empty"},
+                  {"name": "protocol_antiword_text", "type": "string", "description": "text after antiword processing, in case of error will be empty"}]
+        for field in self.PROTOCOL_DATA_FIELDS:
+            field_name = field
+            field_type = "string"
+            field_description = None
+            fields.append({"name": "protocol_{}".format(field_name),
+                           "type": field_type,
+                           "description": field_description})
+        fields.append({"name": "scraper_errors", "type": "string", "description": "comma separated list of errors encountered"})
+        json_table_schema = {"fields": fields}
+        super(PlenumMeetingsResource, self).__init__(name, parent_datapackage_path, json_table_schema,
+                                                     file_fields=["protocol_original", "protocol_antiword_text"])
+        self.descriptor["plenum_errors"] = []
+
+    def _get_plenum_meetings_instance(self, mock=None, **make_kwargs):
+        if mock:
+            return MockPlenumMeetings(full_protocol=True)
+        else:
+            return PlenumMeetings()
+
+    def _data_generator(self, **make_kwargs):
+        for plenum_meeting in self._get_plenum_meetings_instance(**make_kwargs).download(skip_exceptions=make_kwargs.get("skip_exceptions")):
+            if make_kwargs.get("skip_exceptions") and isinstance(plenum_meeting, Exception):
+                self.logger.error("encountered an unexpected exception fetching plenum protocol")
+                self.logger.debug(plenum_meeting, exc_info=1)
+                self.descriptor["plenum_errors"].append(plenum_meeting.message)
+            else:
+                row = self._get_empty_row()
+                scraper_errors = []
+                meeting_path = os.path.join(str(plenum_meeting.year), str(plenum_meeting.month), str(plenum_meeting.day))
+                os.makedirs(self.get_path(meeting_path))
+                row["protocol_original"] = os.path.join(meeting_path, plenum_meeting.url.split("/")[-1])
+                row["protocol_antiword_text"] = os.path.join(meeting_path, "{}.txt".format(plenum_meeting.url.split("/")[-1]))
+                try:
+                    with plenum_meeting.protocol as protocol:
+                        copy(protocol.file_name, self.get_path(row["protocol_original"]))
+                        with open(self.get_path(row["protocol_antiword_text"]), "w") as f:
+                            f.write(protocol.antiword_text)
+                        for field in self.PROTOCOL_DATA_FIELDS:
+                            field_name = field
+                            try:
+                                val = getattr(protocol, field_name)
+                            except Exception, e:
+                                if make_kwargs.get("skip_exceptions"):
+                                    val = ""
+                                    self.logger.debug("error getting plenum protocol {} attribute".format(field_name))
+                                    self.logger.debug(e, exc_info=1)
+                                    scraper_errors.append("error getting protocol_{}: {}".format(field_name, e.message))
+                                else:
+                                    raise
+                            row["protocol_{}".format(field_name)] = val
+                except Exception, e:
+                    if make_kwargs.get("skip_exceptions"):
+                        row["protocol_original"] = ""
+                        row["protocol_antiword_text"] = ""
+                        self.logger.warn("error getting plenum protocol ({}): {}".format(meeting_path, e.message))
+                        self.logger.debug(e, exc_info=1)
+                        scraper_errors.append(e.message)
+                    else:
+                        raise
+                row.update({"day": plenum_meeting.day,
+                            "month": plenum_meeting.month,
+                            "year": plenum_meeting.year,
+                            "protocol_url": plenum_meeting.url,
+                            "scraper_errors": ", ".join(scraper_errors)})
+                yield row
+
+        # for filename, content in [("hello_world.doc", "hello there! (IN DOC FORMAT!)"), ("hello_world.txt", "hello there!"),
+        #                           ("goodbye_world.doc", "goodbye DOC"), ("goodbye_world.txt", "goodbye TXT")]:
+        #     with open(os.path.join(self._base_path, filename), "w") as f:
+        #         f.write(content)
+        # yield {"name": "hello world", "text file": "hello_world.txt", "doc file": "hello_world.doc"}
+        # yield {"name": "goodbye world", "text file": "goodbye_world.txt", "doc file": "goodbye_world.doc"}

--- a/knesset_datapackage/root.py
+++ b/knesset_datapackage/root.py
@@ -1,6 +1,7 @@
 from knesset_datapackage.base import BaseDatapackage, DatapackageResourceLink
 from knesset_datapackage.resources.committees import CommitteesResource, CommitteeMeetingsResource, CommitteeMeetingProtocolsResource
 from knesset_datapackage.resources.members import MembersResource
+from knesset_datapackage.resources.plenum import PlenumMeetingsResource
 from collections import OrderedDict
 
 
@@ -13,4 +14,6 @@ class RootDatapackage(BaseDatapackage):
         ("committee-meetings-protocols", (CommitteeMeetingProtocolsResource, {})),
 
         ("members", (MembersResource, {})),
+
+        ("plenum-meetings", (PlenumMeetingsResource, {})),
     ])

--- a/knesset_datapackage/tests/test_exceptions.py
+++ b/knesset_datapackage/tests/test_exceptions.py
@@ -67,8 +67,7 @@ class ExceptionsTestCase(BaseDatapackageTestCase):
 
     def test_exception_in_resource_while_making_datapackage(self):
         # default behavior - stop processing and raise exception
-        with self.assertRaises(Exception) as cm:
-            self.given_dummy_datapackage_was_made()
+        self.given_dummy_datapackage_was_made()
         self.assertEqual(cm.exception.message, "dummy resource exception")
         # with skip_exceptions enabled
         datapackage = self.given_dummy_datapackage_was_made(skip_exceptions=True)

--- a/knesset_datapackage/tests/test_exceptions.py
+++ b/knesset_datapackage/tests/test_exceptions.py
@@ -41,8 +41,8 @@ class ExceptionsTestCase(BaseDatapackageTestCase):
         self.assert_member_row(results_generator.next(), 200, "")
         self.assert_member_row(results_generator.next(), 201, "")
         self.assert_member_row(results_generator.next(), 202, "")
-        self.assert_member_row(results_generator.next(), "", "exception generating test-members-resource: member with exception on init")
-        self.assert_member_row(results_generator.next(), "", "exception generating test-members-resource: member with exception on parse")
+        self.assert_member_row(results_generator.next(), None, "exception generating test-members-resource: member with exception on init")
+        self.assert_member_row(results_generator.next(), None, "exception generating test-members-resource: member with exception on parse")
 
     def test_members_exception_make(self):
         resource = MockMembersResource("test-members-resource", self.data_root)

--- a/knesset_datapackage/tests/test_exceptions.py
+++ b/knesset_datapackage/tests/test_exceptions.py
@@ -67,7 +67,8 @@ class ExceptionsTestCase(BaseDatapackageTestCase):
 
     def test_exception_in_resource_while_making_datapackage(self):
         # default behavior - stop processing and raise exception
-        self.given_dummy_datapackage_was_made()
+        with self.assertRaises(Exception) as cm:
+            self.given_dummy_datapackage_was_made()
         self.assertEqual(cm.exception.message, "dummy resource exception")
         # with skip_exceptions enabled
         datapackage = self.given_dummy_datapackage_was_made(skip_exceptions=True)

--- a/knesset_datapackage/tests/test_utils.py
+++ b/knesset_datapackage/tests/test_utils.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from ..utils import uncast_value, cast_value
+from datetime import datetime, date
+
+
+class UncastValueTestCase(TestCase):
+
+    def assertUncastValue(self, type_or_partial_schema, casted_value, expected_uncasted_value):
+        schema = {"type": type_or_partial_schema} if isinstance(type_or_partial_schema, (str, unicode)) else type_or_partial_schema
+        schema.setdefault("name", "void")
+        uncasted_value = uncast_value(casted_value, schema)
+        self.assertEqual(uncasted_value, expected_uncasted_value)
+        # now cast the value back - there are some edge-cases for this
+        recasted_value = cast_value(uncasted_value, schema)
+        if schema["type"] == "string" and casted_value is None:
+            self.assertEqual(recasted_value, u"")
+        else:
+            self.assertEqual(recasted_value, casted_value)
+
+    def test(self):
+        for args in (("date", date(2014, 3, 2), "2014-03-02"),
+                     ({"type": "datetime", "format": "fmt:%d/%m/%Y %H:%M"}, datetime(2016, 1, 11, 5, 4), "11/01/2016 05:04"),
+                     ("integer", None, ""),
+                     ("string", None, ""),):
+            self.assertUncastValue(*args)

--- a/knesset_datapackage/utils.py
+++ b/knesset_datapackage/utils.py
@@ -1,5 +1,8 @@
 import logging, sys, os
 from shutil import rmtree
+import json
+import datetime
+import jsontableschema
 
 
 def setup_logging(debug=False):
@@ -20,3 +23,47 @@ def setup_datapath(path=None, delete=False):
     if not os.path.exists(path):
         os.mkdir(path)
     return path
+
+
+def merge_table_schemas(*schemas):
+    merged_schema = {"fields": []}
+    for schema in schemas:
+        if schema.keys() == ["fields"]:
+            for field in schema["fields"]:
+                if field["name"] in [f["name"] for f in merged_schema["fields"]]:
+                    raise Exception("field {} appears in more then 1 merged schema".format(field["name"]))
+                else:
+                    merged_schema["fields"].append(field)
+        else:
+            raise Exception("merge_table_schemas only supports fields attribute in merged schemas")
+    return merged_schema
+
+
+def uncast_value(value, schema):
+    if schema["type"] == "integer" and isinstance(value, int):
+        return str(value).encode("utf-8")
+    elif schema["type"] == "string":
+        if isinstance(value, str):
+            return value.decode("utf-8")
+        elif isinstance(value, unicode):
+            return value
+        else:
+            return json.dumps(value) if value is not None else u""
+    elif schema["type"] in ("date", "datetime") and isinstance(value, (datetime.datetime, datetime.date)):
+        if "format" in schema:
+            if schema["format"].startswith("fmt:"):
+                return value.strftime(schema["format"][4:])
+            else:
+                raise Exception("I don't know how to parse {} format {}".format(schema["type"], schema["format"]))
+        else:
+            return value.isoformat()
+    elif schema["type"] == "array" and isinstance(value, (list, tuple)):
+        return json.dumps(value)
+    elif value is None:
+        return u""
+    else:
+        raise Exception("sorry, I don't know how to uncast field_schema {} for value '{}'".format(schema, value))
+
+
+def cast_value(value, schema):
+    return jsontableschema.Field(schema).cast_value(value)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+unicodecsv==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 unicodecsv==0.14.1
 -e git://github.com/hasadna/knesset-data-python.git@8477ad1297378dfae5d78fbfde87dc81a43157bc#egg=knesset-data
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 unicodecsv==0.14.1
+-e git://github.com/OriHoch/knesset-data-python.git@add-plenum-meetings-html-scraper-copied-from-oknesset#egg=knesset-data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 unicodecsv==0.14.1
--e git://github.com/OriHoch/knesset-data-python.git@add-plenum-meetings-html-scraper-copied-from-oknesset#egg=knesset-data
+-e git://github.com/hasadna/knesset-data-python.git@8477ad1297378dfae5d78fbfde87dc81a43157bc#egg=knesset-data


### PR DESCRIPTION
depends on knesset-data-python changes in https://github.com/hasadna/knesset-data-python/pull/5

#### changelog
* added plenum meetings resource - includes the meeting metadata as well as the meeting protocol files
* support ordering of fields in the descriptor and schema - to have a nicer and more consistent json output (good for users but also for automated tests)
* added --resource argument - to allow to run only for a list of specific resource names
* added --mock argument - causes resources that support it to work against mock objects (for development)
* improve error handling and output
* misc. stability / edge-case / encoding fixes
* added cast_value and uncast_value functions which allow to case and uncast a value according to a field table schema (TODO: move them to tableschema-py library)

