### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     license='GPLv3',
     url='https://github.com/hasadna/knesset-data-datapackage',
     packages=find_packages(exclude=["tests", "test.*"]),
-    install_requires=['knesset-data', 'datapackage', 'iso8601'],
+    install_requires=['knesset-data', 'datapackage<1.0', 'iso8601'],
     entry_points={'console_scripts': ['make_knesset_datapackage = knesset_datapackage.cli:make_datapackage']}
 )


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.